### PR TITLE
Addressing sonarqube review

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.4</version>
+            <version>1.16.8</version>
             <scope>provided</scope>
         </dependency>
 
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.2.0</version>
+            <version>3.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/CircuitBreakerManager.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/CircuitBreakerManager.java
@@ -24,7 +24,7 @@ public class CircuitBreakerManager {
     /**
      * The rate used to determine if the circuit is opened or not.
      */
-    public static enum RateType {
+    public enum RateType {
         MEAN, ONE_MINUTE, FIVE_MINUTES, FIFTEEN_MINUTES;
     }
 
@@ -33,8 +33,9 @@ public class CircuitBreakerManager {
      * and will catch any exception. In case of an exception, it will increase
      * the meter and, eventually, can cause the circuit to open.
      */
+    @FunctionalInterface
     public static interface Operation {
-        public void accept(final Meter meter) throws Exception;
+        public void accept(final Meter meter) throws OperationException;
     }
 
     private final ConcurrentHashMap<String, Meter> circuitBreakerMap;
@@ -93,10 +94,10 @@ public class CircuitBreakerManager {
      *            The circuit name.
      * @param codeBlock
      *            The code block that will be executed.
-     * @throws Exception
+     * @throws OperationException
      *             The exception thrown from the given code block.
      */
-    public void wrapCodeBlock(final String name, final Operation codeBlock) throws Exception {
+    public void wrapCodeBlock(final String name, final Operation codeBlock) throws OperationException {
         final Meter exceptionMeter = this.getMeter(name);
 
         try {
@@ -120,11 +121,11 @@ public class CircuitBreakerManager {
      * @throws CircuitBreakerOpenedException
      *             Thrown if the circuit breaker is opened and the block can't
      *             be executed.
-     * @throws Exception
+     * @throws OperationException
      *             The exception thrown from the given code block.
      */
     public void wrapCodeBlockWithCircuitBreaker(final String name, final Operation codeBlock)
-            throws CircuitBreakerOpenedException, Exception {
+            throws CircuitBreakerOpenedException, OperationException {
         if (this.isCircuitOpen(name)) {
             throw new CircuitBreakerOpenedException(name);
         }

--- a/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/OperationException.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/OperationException.java
@@ -18,10 +18,8 @@ public class OperationException extends Exception {
         super(exception);
     }
 
-    /**
-     * Empty constructor used when we don't have any message or we're not
-     * wrapping any exception.
-     */
     public OperationException() {
+        // Empty constructor used when we don't have any message or we're not
+        // wrapping any exception.
     }
 }

--- a/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/OperationException.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/OperationException.java
@@ -1,0 +1,23 @@
+package com.github.mtakaki.dropwizard.circuitbreaker;
+
+/**
+ * An exception that wraps errors that happens inside a circuit breaker
+ * operation.
+ *
+ * @author mtakaki
+ *
+ */
+public class OperationException extends Exception {
+    private static final long serialVersionUID = 5913294638186584663L;
+
+    public OperationException(final String message) {
+        super(message);
+    }
+
+    public OperationException(final Exception exception) {
+        super(exception);
+    }
+
+    public OperationException() {
+    }
+}

--- a/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/OperationException.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/OperationException.java
@@ -18,6 +18,10 @@ public class OperationException extends Exception {
         super(exception);
     }
 
+    /**
+     * Empty constructor used when we don't have any message or we're not
+     * wrapping any exception.
+     */
     public OperationException() {
     }
 }

--- a/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/jersey/CircuitBreaker.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/jersey/CircuitBreaker.java
@@ -7,11 +7,16 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Annotates a resource method that will use a circuit breaker to prevent issues
+ * from escalating.
+ *
+ * @author mtakaki
+ *
+ */
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
 public @interface CircuitBreaker {
     String name() default "";
-
-    double threshold() default 0D;
 }

--- a/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/jersey/CircuitBreakerApplicationEventListener.java
+++ b/src/main/java/com/github/mtakaki/dropwizard/circuitbreaker/jersey/CircuitBreakerApplicationEventListener.java
@@ -50,7 +50,7 @@ public class CircuitBreakerApplicationEventListener implements ApplicationEventL
             final Optional<String> circuitName = CircuitBreakerApplicationEventListener
                     .getCircuitBreakerName(event.getUriInfo().getMatchedResourceMethod());
 
-            circuitName.ifPresent((actualCircuitName) -> {
+            circuitName.ifPresent(actualCircuitName -> {
                 if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_START
                         && this.circuitBreakerManager.isCircuitOpen(actualCircuitName)) {
                     this.meterMap.get(actualCircuitName + OPEN_CIRCUIT_SUFFIX).mark();

--- a/src/test/java/com/github/mtakaki/dropwizard/circuitbreaker/CircuitBreakerManagerTest.java
+++ b/src/test/java/com/github/mtakaki/dropwizard/circuitbreaker/CircuitBreakerManagerTest.java
@@ -20,8 +20,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import com.github.mtakaki.dropwizard.circuitbreaker.CircuitBreakerManager;
-import com.github.mtakaki.dropwizard.circuitbreaker.CircuitBreakerOpenedException;
 import com.github.mtakaki.dropwizard.circuitbreaker.CircuitBreakerManager.RateType;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -189,7 +187,7 @@ public class CircuitBreakerManagerTest {
 
         try {
             this.circuitBreaker.wrapCodeBlock(METER_NAME, (currentMeter) -> {
-                throw new Exception();
+                throw new OperationException();
             });
         } catch (final Exception e) {
         }
@@ -211,7 +209,7 @@ public class CircuitBreakerManagerTest {
         for (int i = 0; i < 10; i++) {
             try {
                 this.circuitBreaker.wrapCodeBlock(METER_NAME, (currentMeter) -> {
-                    throw new Exception();
+                    throw new OperationException();
                 });
             } catch (final Exception e) {
             }
@@ -238,7 +236,7 @@ public class CircuitBreakerManagerTest {
         for (int i = 0; i < 2; i++) {
             try {
                 this.circuitBreaker.wrapCodeBlock(METER_NAME, (currentMeter) -> {
-                    throw new Exception();
+                    throw new OperationException();
                 });
             } catch (final Exception e) {
             }
@@ -298,7 +296,7 @@ public class CircuitBreakerManagerTest {
         for (int i = 0; i < 2; i++) {
             try {
                 this.circuitBreaker.wrapCodeBlockWithCircuitBreaker(METER_NAME, (currentMeter) -> {
-                    throw new Exception();
+                    throw new OperationException();
                 });
             } catch (final Exception e) {
             }


### PR DESCRIPTION
Addressing a couple of issues raised by sonarqube:
1. Throwing a dedicated exception instead of a generic one (`OperationException`).
2. Removing redundant `static` qualifier from enum.
3. Annotating `Operation` interface with `@FunctionalInterface`.
4. Removing unnecessary parenthesis from lambda expression in `CircuitBreakerApplicationEventListener`.
5. Removing not implemented feature (custom threshold).
